### PR TITLE
Use standard library mock when available

### DIFF
--- a/multipart/tests/test_multipart.py
+++ b/multipart/tests/test_multipart.py
@@ -16,7 +16,10 @@ from .compat import (
 from io import BytesIO
 from six import binary_type, text_type
 
-from mock import MagicMock, Mock, patch
+try:
+    from unittest.mock import MagicMock, Mock, patch
+except ImportError:
+    from mock import MagicMock, Mock, patch
 
 from ..multipart import *
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,15 @@ if sys.version_info[0] >= 3:
 version_re = re.compile(r'((?:\d+)\.(?:\d+)\.(?:\d+))')
 version = version_re.search(version_data).group(0)
 
+tests_require = [
+    'pytest',
+    'pytest-cov',
+    'PyYAML'
+]
+
+if sys.version_info[0:2] < (3, 3):
+    tests_require.append('mock')
+
 setup(name='python-multipart',
       version=version,
       description='A streaming multipart parser for Python',
@@ -27,12 +36,7 @@ setup(name='python-multipart',
       install_requires=[
           'six>=1.4.0',
       ],
-      tests_require=[
-          'pytest',
-          'pytest-cov',
-          'Mock',
-          'PyYAML'
-      ],
+      tests_require=tests_require,
       packages=[
           'multipart',
           'multipart.tests',


### PR DESCRIPTION
Mock is available in the standard library since 3.3.

https://docs.python.org/3/library/unittest.mock.html