### PR TITLE
QuerystringParser: don't raise an AttributeError in __repr__

### DIFF
--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -949,9 +949,9 @@ class QuerystringParser(BaseParser):
         self.callback('end')
 
     def __repr__(self):
-        return "%s(keep_blank_values=%r, strict_parsing=%r, max_size=%r)" % (
+        return "%s(strict_parsing=%r, max_size=%r)" % (
             self.__class__.__name__,
-            self.keep_blank_values, self.strict_parsing, self.max_size
+            self.strict_parsing, self.max_size
         )
 
 

--- a/multipart/tests/test_multipart.py
+++ b/multipart/tests/test_multipart.py
@@ -478,6 +478,10 @@ class TestQuerystringParser(unittest.TestCase):
             (b'another', b'asdf')
         )
 
+    def test_repr(self):
+        # Issue #29; verify we don't assert on repr()
+        _ignored = repr(self.p)
+
 
 class TestOctetStreamParser(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #29 