### PR TITLE
Update .gitmodules for GitHub on Jan 11th and March 15th onwards

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/build/html"]
 	path = docs/build/html
-	url = git://github.com/andrew-d/python-multipart.git
+	url = https://github.com/andrew-d/python-multipart.git
 	branch = gh-pages


### PR DESCRIPTION
Since GitHub is disabling unencrypted git the git:// url needed to be changed to https:// continue to work.