### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/multipart/tests/test_multipart.py
+++ b/multipart/tests/test_multipart.py
@@ -716,7 +716,7 @@ for f in os.listdir(http_tests_dir):
             test_data = f.read()
 
         with open(yaml_file, 'rb') as f:
-            yaml_data = yaml.load(f)
+            yaml_data = yaml.safe_load(f)
 
         http_tests.append({
             'name': fname,


### PR DESCRIPTION
yaml.load in PyYAML 6 requires a Loader argument.  PyYAML recommends using SafeLoader, which is implied if you call yaml.safe_load instead.

https://github.com/yaml/pyyaml/pull/561
https://msg.pyyaml.org/load

Fixes #41