### PR TITLE
Update changelog URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/andrew-d/python-multipart"
 Documentation = "https://andrew-d.github.io/python-multipart/"
-Changelog = "https://github.com/andrew-d/python-multipart/tags"
+Changelog = "https://github.com/andrew-d/python-multipart/blob/master/CHANGELOG.md"
 Source = "https://github.com/andrew-d/python-multipart"
 
 [tool.hatch.version]


### PR DESCRIPTION
Hi. The changelog URL on python-multipart's [PyPI](https://pypi.org/project/python-multipart/) leads to the tags page, which is not very informative. This PR changes the URL to lead to the actual changelog that was added recently.