### PR TITLE
Use single quotes to avoid special zsh chars '[' and ']'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,5 +24,5 @@ If you want to test:
 
 .. code-block:: bash
 
-    $ pip install .[dev]
+    $ pip install '.[dev]'
     $ inv test


### PR DESCRIPTION
Use quotes to avoid special characters (see [issue](https://github.com/andrew-d/python-multipart/issues/69)).