### PR TITLE
Use latest invoke version (2.2.0)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,4 @@ jobs:
           pip install .[dev]
       - name: Test with pytest
         run: |
-          # This should be inv test but invoke does not have python3.11 support yet.
-          # See https://github.com/pyinvoke/invoke/issues/891 for details
-          pytest
+          inv test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pytest==7.2.0",
     "pytest-cov==4.0.0",
     "PyYAML==5.1",
-    "invoke==1.7.3",
+    "invoke==2.2.0",
     "pytest-timeout==2.1.0",
     "hatch",
 ]


### PR DESCRIPTION
Fix for #70.

Now users running python 3.11 will be able to run the tests according to the instructions.