### PR TITLE
Fixing issue #78

### DIFF
--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -110,6 +110,8 @@ def parse_options_header(value: Union[str, bytes]) -> Tuple[bytes, Dict[bytes, b
     options = {}
     for param in params:
         key, value = param
+        if isinstance(value, tuple):
+            value = value[-1]
         # If the value is a filename, we need to fix a bug on IE6 that sends
         # the full file path instead of the filename.
         if key == 'filename':


### PR DESCRIPTION
Fixing the case where `email.message.Message.get_params` returns a `tuple` instead of a `str`